### PR TITLE
Specify requirement that pylibmc be in requirements.txt

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -193,6 +193,12 @@ pylibmc==1.2.2
 django-pylibmc-sasl==0.2.4
 ~~~~
 
+Note that the `pylibmc` requirements must be added directly to your
+`requirements.txt` file and not in any included pip requirement files.
+The Heroku Python buildpack checks the `requirements.txt` file and only
+that file for the presence of `pylibmc` to trigger bootstrapping
+`libmemcached`, which is prerequisite for installing `pylibmc`.
+
 Next, configure your settings.py file the following way:
 
 ~~~~ python


### PR DESCRIPTION
Instructing that a requirement should be added to a project's `requirements.txt` file is not, on its face, taken to mean that a requirement must be added to that file specifically. pip allows for including files so it suffices that a requirement be added to an included `requirements file`. In this case however the `pylibmc` requirement must be explicitly added to the `requirements.txt` file. That should be stated explicitly with explanation.

This should solve a problem for at least [a few other people](https://encrypted.google.com/search?hl=en&q=heroku%20pylibmc%20errors) too.
