### PR TITLE
Update the usage instructions for memcachier-tls-buildpack

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -1082,19 +1082,11 @@ specified in your environment variable and to verify certificates as signed by
 the [MemCachier Root CA](https://www.memcachier.com/MemCachierRootCA.pem).
 
 Use the buildpack in conjunction with another buildpack that actually
-runs your app. To do so, first configure your app to use the
-[multi-buildpack](https://github.com/ddollar/heroku-buildpack-multi):
+runs your app, using Heroku's
+[multiple buildpack](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app)
+feature:
 
-    $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
-
-Next, add a `.buildpacks` file to your app repository. The file should contain
-the Git URL of each buildpack you'd like to use, including this one. For
-example, to run a Python app with TLS support for MemCachier, your
-`.buildpacks` file should look like this:
-
-    $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-python.git
-    https://github.com/memcachier/memcachier-tls-buildpack.git
+    $ heroku buildpacks:add https://github.com/memcachier/memcachier-tls-buildpack.git
 
 Finally, configure your app to connect to `localhost:11211` instead of using
 the `MEMCACHIER_SERVERS` environment variable. _IMPORTANT_ leave your

--- a/documentation.md
+++ b/documentation.md
@@ -1076,7 +1076,7 @@ a [buildpack](https://github.com/memcachier/memcachier-tls-buildpack)
 that proxies the connection to MemCachier and wraps it in a TLS
 connection.
 
-The builpack installs and sets up [stunnel] on localhost listening
+The buildpack installs and sets up [stunnel] on localhost listening
 on port 11211. It configures stunnel to connect to the MemCachier servers
 specified in your environment variable and to verify certificates as signed by
 the [MemCachier Root CA](https://www.memcachier.com/MemCachierRootCA.pem).
@@ -1098,7 +1098,7 @@ example, to run a Python app with TLS support for MemCachier, your
 
 Finally, configure your app to connect to `localhost:11211` instead of using
 the `MEMCACHIER_SERVERS` environment variable. _IMPORTANT_ leave your
-`MEMCACHIER_SERVERS` environent variable unchanged as the TLS
+`MEMCACHIER_SERVERS` environment variable unchanged as the TLS
 buildpack uses it to connect to MemCachier.
 
 <h2 id="1mb-limit">Key-Value size limit (1MB)</h2>


### PR DESCRIPTION
Since the third-party heroku-buildpack-multi is both unmaintained and no longer necessary, now that Heroku natively supports multiple buildpacks:
https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app

See also memcachier/memcachier-tls-buildpack#5.