### PR TITLE
Update `django-memcache.md` replacing `pylibmc` with `django-bmemcached`

### DIFF
--- a/documentation/clients/php/laravel.md
+++ b/documentation/clients/php/laravel.md
@@ -24,7 +24,7 @@ Related tutorials:
 **ENDIF**
 
 As of Laravel 5.3, memcached is supported out of the box with the `php-memcached`
-PECL extention. Instructions on how to install `php-memcached` can be found
+PECL extension. Instructions on how to install `php-memcached` can be found
 **IF(direct)**
 [here](/documentation/php).
 **ENDIF**

--- a/documentation/clients/php/php.md
+++ b/documentation/clients/php/php.md
@@ -30,12 +30,12 @@ We also recommend that you use the [composer dependency
 manager](https://getcomposer.org/) for PHP, although that is up to you.
 **ENDIF**
 
-The `php-memcached` client is not a pure PHP client but a PECL extention that
+The `php-memcached` client is not a pure PHP client but a PECL extension that
 makes use of `libmemcached`. You thus need to install `php-memcached` via your
 OS package manager. In older operating systems you have to make sure libmemcached
 has SASL authentication support enabled but for newer operating systems such as
 Ubuntu 16.04 this is the default. After the installation you need to uncomment
-`;extension=memcached.so` in `/etc/php/conf.d/memcached.ini` for the extention
+`;extension=memcached.so` in `/etc/php/conf.d/memcached.ini` for the extension
 to work.
 **IF(heroku)**
 On Heroku this dependency is already installed and configured.

--- a/heroku_articles/laravel-memcache.md
+++ b/heroku_articles/laravel-memcache.md
@@ -228,7 +228,7 @@ Now that we have an empty database, we can add a table to represent the task lis
 $ php artisan make:migration create_tasks_table --create=tasks
 ```
 
-Tasks should have names, so let's add `name` to the `tasks` table in the newly created `database/migrations/<date>_crate_tasks_table.php` file:
+Tasks should have names, so let's add `name` to the `tasks` table in the newly created `database/migrations/<date>_create_tasks_table.php` file:
 
 ```php
 Schema::create('tasks', function (Blueprint $table) {
@@ -539,7 +539,7 @@ $ heroku addons:create memcachier:dev
 To use use Memcache on your local machine, you also need to complete the
 following steps:
 
-1. Install the `php-memcached` PECL extention via your OS package manager.
+1. Install the `php-memcached` PECL extension via your OS package manager.
 2. Uncomment `;extension=memcached.so` in `/etc/php/conf.d/memcached.ini`.
 3. Run `php -m` to make sure the `memcached` module is loaded.
 


### PR DESCRIPTION
## Update `django-memcache.md` replacing `pylibmc` with `django-bmemcached`

This PR updates the "Scaling a Django Application with Memcache" Heroku article, replacing `pylibmc` with `django-bmemcached`.

I've added `(venv) $ ...` in a few places after I incorrectly ran commands at just `$ ...`.

A few `get hits` and `get misses` references have been updated to be consistent with the new dashboard.

A typos commit is piggybacked in this PR also.