### PR TITLE
Update `django-memcache.md`, remove unnecessary cache `binary` and `behaviour` config

### DIFF
--- a/heroku_articles/django-memcache.md
+++ b/heroku_articles/django-memcache.md
@@ -357,26 +357,8 @@ def get_cache():
         'TIMEOUT': None,
         'LOCATION': servers,
         'OPTIONS': {
-          'binary': True,
           'username': username,
           'password': password,
-          'behaviors': {
-            # Enable faster IO
-            'no_block': True,
-            'tcp_nodelay': True,
-            # Keep connection alive
-            'tcp_keepalive': True,
-            # Timeout settings
-            'connect_timeout': 2000, # ms
-            'send_timeout': 750 * 1000, # us
-            'receive_timeout': 750 * 1000, # us
-            '_poll_timeout': 2000, # ms
-            # Better failover
-            'ketama': True,
-            'remove_failed': 1,
-            'retry_timeout': 2,
-            'dead_timeout': 30,
-          }
         }
       }
     }
@@ -420,6 +402,9 @@ Finally, commit and deploy these changes:
 $ git commit -am "Connecting to memcache."
 $ git push heroku master
 ```
+
+>note
+>[`pylibmc`](https://devcenter.heroku.com/articles/memcachier#django) can be used as an alternative to `django-bmemcached`.
 
 ### Verify Memcache configuration
 


### PR DESCRIPTION
## Update `django-memcache.md`, remove unnecessary cache `binary` and `behaviour` config

This PR updates the "Scaling a Django Application with Memcache" Heroku article, removing cache `binary` and `behaviour` config that was required for `pylibmc`, but no longer required for `django-bmemcached`.

A note is also added mentioning `pylibmc` as an alternative to `django-bmemcached`.