### PR TITLE
Add libmemcached SASL + session caching dependency note

### DIFF
--- a/documentation/clients/php/php.md
+++ b/documentation/clients/php/php.md
@@ -168,6 +168,10 @@ session_start();
 $_SESSION['test'] = 42;
 ```
 
+<p class="alert alert-info">
+Do you get an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> or <code>SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY</code>? If so, try installing <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL.
+</p>
+
 ### Alternative PHP Client -- MemcacheSASL
 
 **IF(direct)**

--- a/documentation/clients/php/php.md
+++ b/documentation/clients/php/php.md
@@ -169,7 +169,7 @@ $_SESSION['test'] = 42;
 ```
 
 <p class="alert alert-info">
-Do you get an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> or <code>SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY</code>? If so, try installing <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL.
+Do you get an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>? If so, try installing <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL.
 </p>
 
 ### Alternative PHP Client -- MemcacheSASL

--- a/documentation/clients/php/php.md
+++ b/documentation/clients/php/php.md
@@ -169,7 +169,7 @@ $_SESSION['test'] = 42;
 ```
 
 <p class="alert alert-info">
-Do you get an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>? If so, try installing <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL.
+Do you get an error <code>FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>? If so, try installing <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL.
 </p>
 
 ### Alternative PHP Client -- MemcacheSASL

--- a/documentation/clients/php/php.md
+++ b/documentation/clients/php/php.md
@@ -36,8 +36,8 @@ We also recommend that you use the [composer dependency
 manager](https://getcomposer.org/) for PHP, although that is up to you.
 **ENDIF**
 
-The `php-memcached` client is not a pure PHP client but a PECL extension that
-makes use of `libmemcached`. You thus need to install `php-memcached` via your
+The [`memcached`](https://pecl.php.net/package/memcached) client is not a pure PHP client but a PECL extension that
+makes use of `libmemcached`. You thus need to install the `memcached` PECL extension via your
 OS package manager. In older operating systems you have to make sure libmemcached
 has SASL authentication support enabled but for newer operating systems such as
 Ubuntu 16.04 this is the default. After the installation you need to uncomment
@@ -150,7 +150,7 @@ session.save_handler=memcached
 memcached.sess_sasl_username=${MEMCACHIER_USERNAME}
 memcached.sess_sasl_password=${MEMCACHIER_PASSWORD}
 
-; PHP 7
+; PHP >=7
 memcached.sess_binary_protocol=1
 session.save_path="${MEMCACHIER_SERVERS}"
 memcached.sess_persistent=On

--- a/documentation/clients/python/django.md
+++ b/documentation/clients/python/django.md
@@ -137,7 +137,7 @@ use an older version.
 
 The `pylibmc` client relies on the C `libmemcached` library. This should be
 fairly straight-forward to install with your package manager on Linux or
-Windows. For macOS users, Homebrew provides and easy solution. We also have a
+Windows. For macOS users, Homebrew provides an easy solution. We also have a
 [blog post](https://blog.memcachier.com/2014/11/05/ubuntu-libmemcached-and-sasl-support/)
 for Ubuntu users on how to do this.
 **IF(heroku)**

--- a/documentation/clients/python/flask.md
+++ b/documentation/clients/python/flask.md
@@ -41,7 +41,7 @@ refer to its [documentation](https://flask-caching.readthedocs.io/en/latest/)
 `Flask-Caching` requires the `pylibmc` client which relies on the C
 `libmemcached` library. This should be
 fairly straight-forward to install with your package manager on Linux or
-Windows. For macOS users, Homebrew provides and easy solution. We also have a
+Windows. For macOS users, Homebrew provides an easy solution. We also have a
 [blog post](https://blog.memcachier.com/2014/11/05/ubuntu-libmemcached-and-sasl-support/)
 for Ubuntu users on how to do this.
 **IF(heroku)**

--- a/documentation/clients/python/python.md
+++ b/documentation/clients/python/python.md
@@ -78,7 +78,7 @@ platform includes `libmemcached`.
 **ENDIF**
 
 <p class="alert alert-info">
-If you are caching sessions, also install <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL. Otherwise, you will likely see errors like <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> or <code>SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY</code>
+If you are caching sessions, also install <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL. Otherwise, you will likely see an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>.
 </p>
 
 Once it's installed, then install `pylibmc`:

--- a/documentation/clients/python/python.md
+++ b/documentation/clients/python/python.md
@@ -78,7 +78,7 @@ platform includes `libmemcached`.
 **ENDIF**
 
 <p class="alert alert-info">
-If you are caching sessions, also install <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL. Otherwise, you will likely see an error <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>.
+If you are caching sessions, also install <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL. Otherwise, you will likely see an error <code>FAILED TO SEND AUTHENTICATION TO SERVER</code> and potentially an associated message <code>no mechanism available</code>.
 </p>
 
 Once it's installed, then install `pylibmc`:

--- a/documentation/clients/python/python.md
+++ b/documentation/clients/python/python.md
@@ -77,6 +77,10 @@ You only need to be concerned about this for local development, the Heroku
 platform includes `libmemcached`.
 **ENDIF**
 
+<p class="alert alert-info">
+If you are caching sessions, also install <code>libsasl2-modules</code> with your OS package manager. <code>libmemcached</code> requires it for session caching support with SASL. Otherwise, you will likely see errors like <code>Warning: session_start(): Failed to write session lock: FAILED TO SEND AUTHENTICATION TO SERVER</code> or <code>SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY</code>
+</p>
+
 Once it's installed, then install `pylibmc`:
 
 ```term

--- a/documentation/clients/supported_clients.md
+++ b/documentation/clients/supported_clients.md
@@ -81,7 +81,7 @@ ASCII auth and an outstanding PR in the main repository.
 | [pymemcache](https://github.com/pinterest/pymemcache) | no | no | no | no |
 | [ultramemcache](https://github.com/esnme/ultramemcache)<sup>2</sup> | no | no | no | ? |
 
-<sup>1</sup> Requires `libmemcached`.  
+<sup>1</sup> Requires `libmemcached` which in turn requires `libsasl2-modules` for session caching support with SASL.  
 <sup>2</sup> C++ bindings.
 
 ### Ruby


### PR DESCRIPTION
Adds a note in relevant places explaining that `libmemcached` requires `libsasl2-modules` to support session caching with SASL.

Renames the `memcached` PECL extension from `php-memcached` to `memcached`. `php-memcached` is the name of the Ubuntu package for the extension.

Fixes a couple of typos.